### PR TITLE
fix(forge): surface forge_status to UI and persist across reloads

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -156,7 +156,7 @@ def get_results(resume_type=None):
         query = '''
             SELECT j.id, j.resume_type, j.source, j.title, j.company,
                    j.location, j.salary, j.url, j.scraped_at, j.search_query,
-                   j.override, j.override_from_score,
+                   j.override, j.override_from_score, j.forge_status,
                    a.decision, a.fit_score, a.quick_checks, a.ai_analysis,
                    (ap.job_id IS NOT NULL) AS applied
             FROM jobs j
@@ -180,6 +180,7 @@ def get_results(resume_type=None):
             'override': bool(row['override']),
             'override_from_score': row['override_from_score'],
             'resume_type': row['resume_type'],
+            'forge_status': row['forge_status'],
             'quick_analysis': json.loads(row['quick_checks'] or '{}'),
             'ai_analysis': json.loads(row['ai_analysis'] or '{}'),
             'job_metadata': {
@@ -466,7 +467,8 @@ def get_job_detail(job_id):
     with get_db() as conn:
         row = conn.execute(
             '''SELECT j.id, j.resume_type, j.title, j.company, j.description,
-                      a.fit_score
+                      j.forge_status,
+                      a.fit_score, a.ai_analysis
                FROM jobs j
                LEFT JOIN analysis a ON a.job_id = j.id
                WHERE j.id = ?''',
@@ -481,6 +483,8 @@ def get_job_detail(job_id):
         'company': row['company'],
         'description': row['description'] or '',
         'fit_score': row['fit_score'] or 0.0,
+        'ai_analysis': row['ai_analysis'] or '{}',
+        'forge_status': row['forge_status'],
     }
 
 

--- a/ui/app.py
+++ b/ui/app.py
@@ -744,6 +744,7 @@ def job_resume_pdf(job_id):
 def job_detail(job_id):
     """Return everything ResumeForge needs to pre-populate its start screen."""
     from core.database import get_job_detail
+    import json as _json
     job = get_job_detail(job_id)
     if not job:
         abort(404)
@@ -751,13 +752,20 @@ def job_detail(job_id):
     resume_path = PROJECT_ROOT / 'resumes' / resume_type / f'{resume_type}.txt'
     if not resume_path.exists():
         abort(404)
+    try:
+        ai = _json.loads(job.get('ai_analysis') or '{}')
+    except Exception:
+        ai = {}
     return jsonify({
-        'job_id':      job['id'],
-        'title':       job['title'],
-        'company':     job['company'],
-        'description': job['description'],
-        'resume_type': resume_type,
-        'resume_text': resume_path.read_text(),
+        'job_id':           job['id'],
+        'title':            job['title'],
+        'company':          job['company'],
+        'description':      job['description'],
+        'resume_type':      resume_type,
+        'resume_text':      resume_path.read_text(),
+        'fit_score':        job['fit_score'],
+        'missing_keywords': ai.get('missing_keywords', []),
+        'forge_status':     job['forge_status'],
     })
 
 

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -223,6 +223,26 @@ function connectSseEvents() {
         btn.replaceWith(link);
     });
 
+    es.addEventListener('forge_failed', (e) => {
+        const payload = JSON.parse(e.data);
+
+        // Close the modal if it's open for this job
+        const modal = document.getElementById('forge-modal');
+        if (modal && modal.dataset.jobId === String(payload.job_id)) {
+            modal.remove();
+        }
+
+        // Replace FORGE button with FAIL marker
+        const btn = document.querySelector(`.forge-btn[data-job-id="${payload.job_id}"]`);
+        if (!btn) return;
+        const span = document.createElement('span');
+        span.className = 'forge-btn fail-link';
+        span.dataset.jobId = String(payload.job_id);
+        span.textContent = '[ FAIL ]';
+        if (payload.reason) span.title = payload.reason;
+        btn.replaceWith(span);
+    });
+
     es.onerror = () => {
         // Reconnect after 5s on connection drop
         es.close();
@@ -344,9 +364,13 @@ function buildResultsTable(results) {
         const considerBtn = showConsider
             ? `<button class="consider-btn" onclick="markConsider(${r.id}, ${score}, this)">Consider</button>`
             : '';
-        const forgeBtn = r.decision === 'STRONG_MATCH'
-            ? `<button class="forge-btn" data-job-id="${r.id}" onclick="openForgeModal(${r.id})">[ FORGE ]</button>`
-            : '';
+        const forgeBtn = r.forge_status === 'pass'
+            ? `<a href="/api/jobs/${r.id}/resume" target="_blank" class="forge-btn pass-link" data-job-id="${r.id}">[ PASS ]</a>`
+            : r.forge_status === 'fail'
+                ? `<span class="forge-btn fail-link" data-job-id="${r.id}">[ FAIL ]</span>`
+                : r.decision === 'STRONG_MATCH'
+                    ? `<button class="forge-btn" data-job-id="${r.id}" onclick="openForgeModal(${r.id})">[ FORGE ]</button>`
+                    : '';
         return `<tr class="${rowClass}" data-search-query="${searchQuery}" data-job-id="${r.id}">
             <td class="applied-cb-cell"><input type="checkbox" class="applied-cb" ${r.applied ? 'checked' : ''} onchange="toggleApplied(${r.id}, this)"></td>
             <td class="${decisionClass}" data-decision-cell>${r.decision}</td>

--- a/ui/static/style.css
+++ b/ui/static/style.css
@@ -333,6 +333,8 @@ tr:hover td { background: var(--bg-panel); }
 .forge-btn { background: transparent; border: 1px solid #00ff88; color: #00ff88; padding: 2px 8px; font-family: monospace; font-size: 11px; cursor: pointer; }
 .forge-btn:hover { background: #00ff8822; }
 a.pass-link { text-decoration: none; display: inline-block; }
+span.fail-link { border-color: #ff4444; color: #ff4444; cursor: default; display: inline-block; }
+span.fail-link:hover { background: transparent; }
 .consider-cell { width: 80px; text-align: center; }
 
 .score-high  { color: var(--green); }


### PR DESCRIPTION
The UI rendered FORGE buttons regardless of forge_status because get_results never selected the column and app.js never checked it. PASS state was only visible during a live SSE event; page reloads reverted completed jobs to FORGE.

Changes:
- core/database.py: get_job_detail and get_results now select and return forge_status. get_job_detail also returns ai_analysis so /api/jobs/<id>/detail can surface missing_keywords to ResumeForge.
- ui/app.py: /api/jobs/<id>/detail returns fit_score, missing_keywords (parsed from ai_analysis), and forge_status.
- ui/static/app.js: render-time check for forge_status renders PASS link, FAIL span, or FORGE button based on state. Added forge_failed SSE listener mirroring the existing forge_complete one so live runs swap in real time.
- ui/static/style.css: .fail-link red border distinguishes failed forge from passed at a glance.